### PR TITLE
Fix incorrect assembly name in cli tool.

### DIFF
--- a/src/EnumGenerator.Cli/EnumGenerator.Cli.csproj
+++ b/src/EnumGenerator.Cli/EnumGenerator.Cli.csproj
@@ -6,7 +6,7 @@
     <LangVersion>7.3</LangVersion>
     <CodeAnalysisRuleSet>../analyzers.ruleset</CodeAnalysisRuleSet>
 
-    <AssemblyName>enum-generator</AssemblyName>
+    <AssemblyName>dotnet-enum-generator</AssemblyName>
     <RootNamespace>EnumGenerator.Cli</RootNamespace>
 
     <PackageId>EnumGenerator.Cli</PackageId>


### PR DESCRIPTION
Needs to be prefixed by `dotnet-` for the cli tooling to pick it up.