### PR TITLE
Rename 'Export' to 'ExportCSharp'.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Major.Minor adjust manually -->
   <PropertyGroup>
-    <VersionPrefix>2.1</VersionPrefix>
+    <VersionPrefix>3.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- Automatically set suffix info based on environment args (if availble) -->

--- a/src/EnumGenerator.Cli/Application.cs
+++ b/src/EnumGenerator.Cli/Application.cs
@@ -127,7 +127,7 @@ namespace EnumGenerator.Cli
             string csharp = null;
             try
             {
-                csharp = enumDefinition.Export(
+                csharp = enumDefinition.ExportCSharp(
                     enumNamespace,
                     indentMode,
                     indentSize,

--- a/src/EnumGenerator.Cli/readme.md
+++ b/src/EnumGenerator.Cli/readme.md
@@ -6,7 +6,7 @@ Can be used to generate c# enum files from json files.
 
 Add a reference to the cli-tool to a `ItemGroup` section your of your csproj.
 ```xml
-<DotNetCliToolReference Include="EnumGenerator.Cli" Version="1.0.*" />
+<DotNetCliToolReference Include="EnumGenerator.Cli" Version="3.0.*" />
 ```
 
 ## Usage

--- a/src/EnumGenerator.Core/Exporter/CSharpExporter.cs
+++ b/src/EnumGenerator.Core/Exporter/CSharpExporter.cs
@@ -95,7 +95,7 @@ namespace EnumGenerator.Core.Exporter
             if (storageType == StorageType.Implicit)
                 builder.Write($"public enum {enumDefinition.Identifier}");
             else
-                builder.Write($"public enum {enumDefinition.Identifier} : {storageType.GetKeyword()}");
+                builder.Write($"public enum {enumDefinition.Identifier} : {storageType.GetCSharpKeyword()}");
             builder.StartScope(curlyBracketMode);
 
             var first = true;

--- a/src/EnumGenerator.Core/Exporter/CSharpExporter.cs
+++ b/src/EnumGenerator.Core/Exporter/CSharpExporter.cs
@@ -30,7 +30,7 @@ namespace EnumGenerator.Core.Exporter
         /// <param name="storageType">Underlying enum storage-type to use</param>
         /// <param name="curlyBracketMode">Mode to use when writing curly brackets</param>
         /// <returns>String containing the genenerated c# sourcecode</returns>
-        public static string Export(
+        public static string ExportCSharp(
             this EnumDefinition enumDefinition,
             string @namespace = null,
             CodeBuilder.IndentMode indentMode = CodeBuilder.IndentMode.Spaces,

--- a/src/EnumGenerator.Core/Exporter/StorageType.cs
+++ b/src/EnumGenerator.Core/Exporter/StorageType.cs
@@ -6,48 +6,48 @@ namespace EnumGenerator.Core.Exporter
     public enum StorageType
     {
         /// <summary>
-        /// Don't output a specific storage type. (This will let the c# compiler decide)
+        /// Don't output a specific storage type.
         /// </summary>
         Implicit = 0,
 
         /// <summary>
-        /// Specify 'byte' as the underlying storage type for the enum.
+        /// Specify 'unsigned 8 bit' as the underlying storage type for the enum.
         /// </summary>
-        Byte = 1,
+        Unsigned8Bit = 1,
 
         /// <summary>
-        /// Specify 'sbyte' as the underlying storage type for the enum.
+        /// Specify 'signed 8 bit' as the underlying storage type for the enum.
         /// </summary>
-        Sbyte = 2,
+        Signed8Bit = 2,
 
         /// <summary>
-        /// Specify 'short' as the underlying storage type for the enum.
+        /// Specify 'signed 16 bit' as the underlying storage type for the enum.
         /// </summary>
-        Short = 3,
+        Signed16Bit = 3,
 
         /// <summary>
-        /// Specify 'ushort' as the underlying storage type for the enum.
+        /// Specify 'unsigned 16 bit' as the underlying storage type for the enum.
         /// </summary>
-        Ushort = 4,
+        Unsigned16Bit = 4,
 
         /// <summary>
-        /// Specify 'int' as the underlying storage type for the enum.
+        /// Specify 'signed 32 bit' as the underlying storage type for the enum.
         /// </summary>
-        Int = 5,
+        Signed32Bit = 5,
 
         /// <summary>
-        /// Specify 'uint' as the underlying storage type for the enum.
+        /// Specify 'unsigned 32 bit' as the underlying storage type for the enum.
         /// </summary>
-        Uint = 6,
+        Unsigned32Bit = 6,
 
         /// <summary>
-        /// Specify 'long' as the underlying storage type for the enum.
+        /// Specify 'signed 64 bit' as the underlying storage type for the enum.
         /// </summary>
-        Long = 7,
+        Signed64Bit = 7,
 
         /// <summary>
-        /// Specify 'ulong' as the underlying storage type for the enum.
+        /// Specify 'unsigned 64 bit' as the underlying storage type for the enum.
         /// </summary>
-        Ulong = 8
+        Unsigned64Bit = 8
     }
 }

--- a/src/EnumGenerator.Core/Exporter/StorageTypeExtensions.cs
+++ b/src/EnumGenerator.Core/Exporter/StorageTypeExtensions.cs
@@ -18,21 +18,21 @@ namespace EnumGenerator.Core.Exporter
             {
                 case StorageType.Implicit:
                     return int.MinValue;
-                case StorageType.Byte:
+                case StorageType.Unsigned8Bit:
                     return byte.MinValue;
-                case StorageType.Sbyte:
+                case StorageType.Signed8Bit:
                     return sbyte.MinValue;
-                case StorageType.Short:
+                case StorageType.Signed16Bit:
                     return short.MinValue;
-                case StorageType.Ushort:
+                case StorageType.Unsigned16Bit:
                     return ushort.MinValue;
-                case StorageType.Int:
+                case StorageType.Signed32Bit:
                     return int.MinValue;
-                case StorageType.Uint:
+                case StorageType.Unsigned32Bit:
                     return uint.MinValue;
-                case StorageType.Long:
+                case StorageType.Signed64Bit:
                     return long.MinValue;
-                case StorageType.Ulong:
+                case StorageType.Unsigned64Bit:
                     return 0;
                 default:
                     throw new ArgumentException($"Unsupported storage-type: '{storageType}'", nameof(storageType));
@@ -54,21 +54,21 @@ namespace EnumGenerator.Core.Exporter
             {
                 case StorageType.Implicit:
                     return int.MaxValue;
-                case StorageType.Byte:
+                case StorageType.Unsigned8Bit:
                     return byte.MaxValue;
-                case StorageType.Sbyte:
+                case StorageType.Signed8Bit:
                     return sbyte.MaxValue;
-                case StorageType.Short:
+                case StorageType.Signed16Bit:
                     return short.MaxValue;
-                case StorageType.Ushort:
+                case StorageType.Unsigned16Bit:
                     return ushort.MaxValue;
-                case StorageType.Int:
+                case StorageType.Signed32Bit:
                     return int.MaxValue;
-                case StorageType.Uint:
+                case StorageType.Unsigned32Bit:
                     return uint.MaxValue;
-                case StorageType.Long:
+                case StorageType.Signed64Bit:
                     return long.MaxValue;
-                case StorageType.Ulong:
+                case StorageType.Unsigned64Bit:
                     /*  Note: We do not support numbers larger then long.MaxValue as we internally use
                     long's to represent the values. */
                     return long.MaxValue;
@@ -82,28 +82,28 @@ namespace EnumGenerator.Core.Exporter
         /// </summary>
         /// <param name="storageType">Storage-type to get the keyword for</param>
         /// <returns>Csharp keyword for the given storage-type</returns>
-        public static string GetKeyword(this StorageType storageType)
+        public static string GetCSharpKeyword(this StorageType storageType)
         {
             switch (storageType)
             {
-                case StorageType.Byte:
+                case StorageType.Unsigned8Bit:
                     return "byte";
-                case StorageType.Sbyte:
+                case StorageType.Signed8Bit:
                     return "sbyte";
-                case StorageType.Short:
+                case StorageType.Signed16Bit:
                     return "short";
-                case StorageType.Ushort:
+                case StorageType.Unsigned16Bit:
                     return "ushort";
-                case StorageType.Int:
+                case StorageType.Signed32Bit:
                     return "int";
-                case StorageType.Uint:
+                case StorageType.Unsigned32Bit:
                     return "uint";
-                case StorageType.Long:
+                case StorageType.Signed64Bit:
                     return "long";
-                case StorageType.Ulong:
+                case StorageType.Unsigned64Bit:
                     return "ulong";
                 default:
-                    throw new ArgumentException($"Storage-type: '{storageType}' has no keyword", nameof(storageType));
+                    throw new ArgumentException($"Storage-type: '{storageType}' has no keyword in csharp", nameof(storageType));
             }
         }
     }

--- a/src/EnumGenerator.Core/readme.md
+++ b/src/EnumGenerator.Core/readme.md
@@ -11,11 +11,11 @@ Can be used for more complex integration into a build pipeline, for simple use-c
 There are two ways to add the nuget package:
 1. Run:
 ```bash
-dotnet add package EnumGenerator.Core --version '1.0.*'
+dotnet add package EnumGenerator.Core --version '3.0.*'
 ```
 2. Add the following to a `ItemGroup` section of your csproj:
 ```xml
-<PackageReference Include="EnumGenerator.Core" Version="1.0.*" />
+<PackageReference Include="EnumGenerator.Core" Version="3.0.*" />
 ```
 
 ## Usage

--- a/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
@@ -27,7 +27,7 @@ namespace EnumGenerator.Tests.Builder
             builder.PushEntry("A", -1);
             var enumDef = builder.Build();
 
-            enumDef.ExportCSharp(storageType: StorageType.Byte);
+            enumDef.ExportCSharp(storageType: StorageType.Unsigned8Bit);
         });
 
         [Fact]
@@ -233,7 +233,7 @@ namespace A.B.C
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.ExportCSharp(storageType: StorageType.Byte);
+            var export = enumDef.ExportCSharp(storageType: StorageType.Unsigned8Bit);
 
             Assert.Equal(
                 expected:

--- a/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class CSharpExporterTests
     {
-        private const string Version = "2.1.0.0";
+        private const string Version = "3.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
@@ -17,7 +17,7 @@ namespace EnumGenerator.Tests.Builder
             builder.PushEntry("A", 1);
             var enumDef = builder.Build();
 
-            enumDef.Export(@namespace: "0Test");
+            enumDef.ExportCSharp(@namespace: "0Test");
         });
 
         [Fact]
@@ -27,7 +27,7 @@ namespace EnumGenerator.Tests.Builder
             builder.PushEntry("A", -1);
             var enumDef = builder.Build();
 
-            enumDef.Export(storageType: StorageType.Byte);
+            enumDef.ExportCSharp(storageType: StorageType.Byte);
         });
 
         [Fact]
@@ -38,7 +38,7 @@ namespace EnumGenerator.Tests.Builder
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export();
+            var export = enumDef.ExportCSharp();
 
             Assert.Equal(
                 expected:
@@ -69,7 +69,7 @@ public enum TestEnum
             builder.PushEntry("B", -2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export();
+            var export = enumDef.ExportCSharp();
 
             Assert.Equal(
                 expected:
@@ -100,7 +100,7 @@ public enum TestEnum
             builder.PushEntry("B", 2, "This is entry B.");
             var enumDef = builder.Build();
 
-            var export = enumDef.Export();
+            var export = enumDef.ExportCSharp();
 
             Assert.Equal(
                 expected:
@@ -137,7 +137,7 @@ public enum TestEnum
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export(indentMode: Core.Utilities.CodeBuilder.IndentMode.Tabs);
+            var export = enumDef.ExportCSharp(indentMode: Core.Utilities.CodeBuilder.IndentMode.Tabs);
 
             Assert.Equal(
                 expected:
@@ -168,7 +168,7 @@ public enum TestEnum
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export(spaceIndentSize: 2);
+            var export = enumDef.ExportCSharp(spaceIndentSize: 2);
 
             Assert.Equal(
                 expected:
@@ -199,7 +199,7 @@ public enum TestEnum
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export(@namespace: "A.B.C");
+            var export = enumDef.ExportCSharp(@namespace: "A.B.C");
 
             Assert.Equal(
                 expected:
@@ -233,7 +233,7 @@ namespace A.B.C
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export(storageType: StorageType.Byte);
+            var export = enumDef.ExportCSharp(storageType: StorageType.Byte);
 
             Assert.Equal(
                 expected:
@@ -264,7 +264,7 @@ public enum TestEnum : byte
             builder.PushEntry("B", 2);
             var enumDef = builder.Build();
 
-            var export = enumDef.Export(@namespace: "Test", curlyBracketMode: CurlyBracketMode.SameLine);
+            var export = enumDef.ExportCSharp(@namespace: "Test", curlyBracketMode: CurlyBracketMode.SameLine);
 
             Assert.Equal(
                 expected:

--- a/src/EnumGenerator.Tests/Exporter/StorageTypeValidatorTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/StorageTypeValidatorTests.cs
@@ -22,44 +22,44 @@ namespace EnumGenerator.Tests.Builder
         {
             // Min values are valid.
             yield return (StorageType.Implicit, int.MinValue, valid: true);
-            yield return (StorageType.Byte, byte.MinValue, valid: true);
-            yield return (StorageType.Sbyte, sbyte.MinValue, valid: true);
-            yield return (StorageType.Short, short.MinValue, valid: true);
-            yield return (StorageType.Ushort, ushort.MinValue, valid: true);
-            yield return (StorageType.Int, int.MinValue, valid: true);
-            yield return (StorageType.Uint, uint.MinValue, valid: true);
-            yield return (StorageType.Long, long.MinValue, valid: true);
-            yield return (StorageType.Ulong, 0, valid: true);
+            yield return (StorageType.Unsigned8Bit, byte.MinValue, valid: true);
+            yield return (StorageType.Signed8Bit, sbyte.MinValue, valid: true);
+            yield return (StorageType.Signed16Bit, short.MinValue, valid: true);
+            yield return (StorageType.Unsigned16Bit, ushort.MinValue, valid: true);
+            yield return (StorageType.Signed32Bit, int.MinValue, valid: true);
+            yield return (StorageType.Unsigned32Bit, uint.MinValue, valid: true);
+            yield return (StorageType.Signed64Bit, long.MinValue, valid: true);
+            yield return (StorageType.Unsigned64Bit, 0, valid: true);
 
             // Max values are valid.
             yield return (StorageType.Implicit, int.MaxValue, valid: true);
-            yield return (StorageType.Byte, byte.MaxValue, valid: true);
-            yield return (StorageType.Sbyte, sbyte.MaxValue, valid: true);
-            yield return (StorageType.Short, short.MaxValue, valid: true);
-            yield return (StorageType.Ushort, ushort.MaxValue, valid: true);
-            yield return (StorageType.Int, int.MaxValue, valid: true);
-            yield return (StorageType.Uint, uint.MaxValue, valid: true);
-            yield return (StorageType.Long, long.MaxValue, valid: true);
-            yield return (StorageType.Ulong, long.MaxValue, valid: true);
+            yield return (StorageType.Unsigned8Bit, byte.MaxValue, valid: true);
+            yield return (StorageType.Signed8Bit, sbyte.MaxValue, valid: true);
+            yield return (StorageType.Signed16Bit, short.MaxValue, valid: true);
+            yield return (StorageType.Unsigned16Bit, ushort.MaxValue, valid: true);
+            yield return (StorageType.Signed32Bit, int.MaxValue, valid: true);
+            yield return (StorageType.Unsigned32Bit, uint.MaxValue, valid: true);
+            yield return (StorageType.Signed64Bit, long.MaxValue, valid: true);
+            yield return (StorageType.Unsigned64Bit, long.MaxValue, valid: true);
 
             // Too small is invalid.
             yield return (StorageType.Implicit, long.MinValue, valid: false);
-            yield return (StorageType.Byte, long.MinValue, valid: false);
-            yield return (StorageType.Sbyte, long.MinValue, valid: false);
-            yield return (StorageType.Short, long.MinValue, valid: false);
-            yield return (StorageType.Ushort, long.MinValue, valid: false);
-            yield return (StorageType.Int, long.MinValue, valid: false);
-            yield return (StorageType.Uint, long.MinValue, valid: false);
-            yield return (StorageType.Ulong, long.MinValue, valid: false);
+            yield return (StorageType.Unsigned8Bit, long.MinValue, valid: false);
+            yield return (StorageType.Signed8Bit, long.MinValue, valid: false);
+            yield return (StorageType.Signed16Bit, long.MinValue, valid: false);
+            yield return (StorageType.Unsigned16Bit, long.MinValue, valid: false);
+            yield return (StorageType.Signed32Bit, long.MinValue, valid: false);
+            yield return (StorageType.Unsigned32Bit, long.MinValue, valid: false);
+            yield return (StorageType.Unsigned64Bit, long.MinValue, valid: false);
 
             // Too big in invalid.
             yield return (StorageType.Implicit, long.MaxValue, valid: false);
-            yield return (StorageType.Byte, long.MaxValue, valid: false);
-            yield return (StorageType.Sbyte, long.MaxValue, valid: false);
-            yield return (StorageType.Short, long.MaxValue, valid: false);
-            yield return (StorageType.Ushort, long.MaxValue, valid: false);
-            yield return (StorageType.Int, long.MaxValue, valid: false);
-            yield return (StorageType.Uint, long.MaxValue, valid: false);
+            yield return (StorageType.Unsigned8Bit, long.MaxValue, valid: false);
+            yield return (StorageType.Signed8Bit, long.MaxValue, valid: false);
+            yield return (StorageType.Signed16Bit, long.MaxValue, valid: false);
+            yield return (StorageType.Unsigned16Bit, long.MaxValue, valid: false);
+            yield return (StorageType.Signed32Bit, long.MaxValue, valid: false);
+            yield return (StorageType.Unsigned32Bit, long.MaxValue, valid: false);
         }
     }
 }


### PR DESCRIPTION
Prepares for a potential future where we can export
different languages.

Breaking changes so next release will be major number
bump.