### PR TITLE
Remove Microsoft.Extensions.Logging dependency from Core

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Major.Minor adjust manually -->
   <PropertyGroup>
-    <VersionPrefix>3.5</VersionPrefix>
+    <VersionPrefix>4.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- Automatically set suffix info based on environment args (if availble) -->

--- a/src/EnumGenerator.Cli/Application.cs
+++ b/src/EnumGenerator.Cli/Application.cs
@@ -18,7 +18,7 @@ namespace EnumGenerator.Cli
     {
         private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
-        private readonly ILogger logger;
+        private readonly Core.ILogger logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Application"/> class.
@@ -29,7 +29,7 @@ namespace EnumGenerator.Cli
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            this.logger = logger;
+            this.logger = new LoggerAdapter(logger);
         }
 
         /// <summary>

--- a/src/EnumGenerator.Cli/LoggerAdapter.cs
+++ b/src/EnumGenerator.Cli/LoggerAdapter.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace EnumGenerator.Cli
+{
+    /// <summary>
+    /// Adapt a <see cref="Microsoft.Extensions.Logging.ILogger"/> to a <see cref="Core.ILogger"/>.
+    /// </summary>
+    public sealed class LoggerAdapter : Core.ILogger
+    {
+        private readonly Microsoft.Extensions.Logging.ILogger sink;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerAdapter"/> class.
+        /// </summary>
+        /// <param name="sink">Logger to output to.</param>
+        public LoggerAdapter(Microsoft.Extensions.Logging.ILogger sink)
+        {
+            this.sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        }
+
+        /// <inheritdoc/>
+        public void LogTrace(string message) => this.sink.LogTrace(message);
+
+        /// <inheritdoc/>
+        public void LogDebug(string message) => this.sink.LogDebug(message);
+
+        /// <inheritdoc/>
+        public void LogInformation(string message) => this.sink.LogInformation(message);
+
+        /// <inheritdoc/>
+        public void LogWarning(string message) => this.sink.LogWarning(message);
+
+        /// <inheritdoc/>
+        public void LogError(string message) => this.sink.LogError(message);
+
+        /// <inheritdoc/>
+        public void LogCritical(string message) => this.sink.LogCritical(message);
+    }
+}

--- a/src/EnumGenerator.Cli/readme.md
+++ b/src/EnumGenerator.Cli/readme.md
@@ -6,7 +6,7 @@ Can be used to generate c# / f# / vb / cil enum files from json files.
 
 Add a reference to the cli-tool to a `ItemGroup` section your of your csproj.
 ```xml
-<DotNetCliToolReference Include="EnumGenerator.Cli" Version="3.5.*" />
+<DotNetCliToolReference Include="EnumGenerator.Cli" Version="4.0.*" />
 ```
 
 ## Usage

--- a/src/EnumGenerator.Core/EnumGenerator.Core.csproj
+++ b/src/EnumGenerator.Core/EnumGenerator.Core.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <!-- Dependencies -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.4" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/src/EnumGenerator.Core/Exporter/StorageTypeValidator.cs
+++ b/src/EnumGenerator.Core/Exporter/StorageTypeValidator.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace EnumGenerator.Core.Exporter
 {
     /// <summary>

--- a/src/EnumGenerator.Core/ILogger.cs
+++ b/src/EnumGenerator.Core/ILogger.cs
@@ -1,0 +1,44 @@
+namespace EnumGenerator.Core
+{
+    /// <summary>
+    /// Interface for a sink of diagnostic information.
+    /// </summary>
+    public interface ILogger
+    {
+        /// <summary>
+        /// Log a trace-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogTrace(string message);
+
+        /// <summary>
+        /// Log a debug-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogDebug(string message);
+
+        /// <summary>
+        /// Log a information-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogInformation(string message);
+
+        /// <summary>
+        /// Log a warning-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogWarning(string message);
+
+        /// <summary>
+        /// Log a error-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogError(string message);
+
+        /// <summary>
+        /// Log a critical-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogCritical(string message);
+    }
+}

--- a/src/EnumGenerator.Core/Mapping/Context.cs
+++ b/src/EnumGenerator.Core/Mapping/Context.cs
@@ -1,5 +1,4 @@
 using System;
-using Microsoft.Extensions.Logging;
 
 namespace EnumGenerator.Core.Mapping
 {

--- a/src/EnumGenerator.Core/Mapping/JsonMapper.cs
+++ b/src/EnumGenerator.Core/Mapping/JsonMapper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/EnumGenerator.Core/readme.md
+++ b/src/EnumGenerator.Core/readme.md
@@ -11,11 +11,11 @@ Can be used for more complex integration into a build pipeline, for simple use-c
 There are two ways to add the nuget package:
 1. Run:
 ```bash
-dotnet add package EnumGenerator.Core --version '3.5.*'
+dotnet add package EnumGenerator.Core --version '4.0.*'
 ```
 2. Add the following to a `ItemGroup` section of your csproj:
 ```xml
-<PackageReference Include="EnumGenerator.Core" Version="3.5.*" />
+<PackageReference Include="EnumGenerator.Core" Version="4.0.*" />
 ```
 
 ## Usage

--- a/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class CSharpExporterTests
     {
-        private const string Version = "3.5.0.0";
+        private const string Version = "4.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/CilExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CilExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class CilExporterTests
     {
-        private const string Version = "3.5.0.0";
+        private const string Version = "4.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/FSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/FSharpExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class FSharpExporterTests
     {
-        private const string Version = "3.5.0.0";
+        private const string Version = "4.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/VisualBasicExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/VisualBasicExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class VisualBasicExporterTests
     {
-        private const string Version = "3.5.0.0";
+        private const string Version = "4.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>


### PR DESCRIPTION
The dependency chain was too big for just a `ILogger` interface. This adds a custom `ILogger` interface to `EnumGenerator.Core` and adds an adapter in the cli application.