### PR TITLE
Update the GlobalTool to target netcoreapp 3.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Major.Minor adjust manually -->
   <PropertyGroup>
-    <VersionPrefix>4.1</VersionPrefix>
+    <VersionPrefix>5.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- Automatically set suffix info based on environment args (if availble) -->

--- a/src/EnumGenerator.Cli/readme.md
+++ b/src/EnumGenerator.Cli/readme.md
@@ -6,7 +6,7 @@ Can be used to generate c# / f# / vb / cil enum files from json files.
 
 Add a reference to the cli-tool to a `ItemGroup` section your of your csproj.
 ```xml
-<DotNetCliToolReference Include="EnumGenerator.Cli" Version="4.1.*" />
+<DotNetCliToolReference Include="EnumGenerator.Cli" Version="5.0.*" />
 ```
 
 ## Usage

--- a/src/EnumGenerator.Core/readme.md
+++ b/src/EnumGenerator.Core/readme.md
@@ -11,11 +11,11 @@ Can be used for more complex integration into a build pipeline, for simple use-c
 There are two ways to add the nuget package:
 1. Run:
 ```bash
-dotnet add package EnumGenerator.Core --version '4.1.*'
+dotnet add package EnumGenerator.Core --version '5.0.*'
 ```
 2. Add the following to a `ItemGroup` section of your csproj:
 ```xml
-<PackageReference Include="EnumGenerator.Core" Version="4.1.*" />
+<PackageReference Include="EnumGenerator.Core" Version="5.0.*" />
 ```
 
 ## Usage

--- a/src/EnumGenerator.GlobalTool/EnumGenerator.GlobalTool.csproj
+++ b/src/EnumGenerator.GlobalTool/EnumGenerator.GlobalTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <CodeAnalysisRuleSet>../analyzers.ruleset</CodeAnalysisRuleSet>
 

--- a/src/EnumGenerator.Tests/EnumGenerator.Tests.csproj
+++ b/src/EnumGenerator.Tests/EnumGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <CodeAnalysisRuleSet>../analyzers.ruleset</CodeAnalysisRuleSet>
 

--- a/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CSharpExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class CSharpExporterTests
     {
-        private const string Version = "4.1.0.0";
+        private const string Version = "5.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/CilExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/CilExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class CilExporterTests
     {
-        private const string Version = "4.1.0.0";
+        private const string Version = "5.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/FSharpExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/FSharpExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class FSharpExporterTests
     {
-        private const string Version = "4.1.0.0";
+        private const string Version = "5.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>

--- a/src/EnumGenerator.Tests/Exporter/VisualBasicExporterTests.cs
+++ b/src/EnumGenerator.Tests/Exporter/VisualBasicExporterTests.cs
@@ -8,7 +8,7 @@ namespace EnumGenerator.Tests.Builder
 {
     public sealed class VisualBasicExporterTests
     {
-        private const string Version = "4.1.0.0";
+        private const string Version = "5.0.0.0";
 
         [Fact]
         public void ThrowsIfExportedWithInvalidNamespace() => Assert.Throws<InvalidNamespaceException>(() =>


### PR DESCRIPTION
The cli will have to remain at `netcoreapp 2.2` unfortunately, as `Project tools (DotnetCliTool)` are no longer supported on `core 3.0`. 